### PR TITLE
a better way to load twig-markdown extension

### DIFF
--- a/README-composer.mkd
+++ b/README-composer.mkd
@@ -1,0 +1,62 @@
+## Installation with composer
+
+- Install composer in your project:
+
+```shell
+curl -s http://getcomposer.org/installer | php
+```
+
+- Create a composer.json file in your project root:
+
+```javascript
+{
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "michelf/php-markdown",
+                "version": "1.0",
+                "dist": {
+                    "url": "https://github.com/michelf/php-markdown/zipball/extra",
+                    "type": "zip"
+                },
+                "autoload": {
+                    "files": [
+                        "markdown.php"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "vcs",
+            "url": "http://github.com/geta6/Twig-Markdown"
+        }
+    ],
+    "require": {
+        "michelf/php-markdown": "1.*",
+        "geta6/twig-markdown": "@dev"
+    }
+}
+```
+
+- Install via composer
+
+```shell
+php composer.phar install
+```
+
+## Usage
+
+```php
+require 'vendor/autoload.php';
+
+$loader = new Twig_Loader_String();
+$twig = new Twig_Environment($loader);
+$twig->addExtension(new Twig_Extension_Markdown());
+
+echo $twig->render('
+{% markdown %}
+###Hello {{ name }}!###
+{% endmarkdown %}
+', array('name' => 'Twig-Markdown'));
+```

--- a/README.mkd
+++ b/README.mkd
@@ -20,8 +20,8 @@ or
 $app->register(~~twig~~);
 
 include '/path/to/markdown.php';
-include __DIR__.'/../vendor/twig-markdown/lib/Twig/Extensions/Core.php';
-$app['twig']->addExtension(new Twig_Markdown_Extension());
+include __DIR__.'/../vendor/twig-markdown/lib/Twig/Extensions/Markdown.php';
+$app['twig']->addExtension(new Twig_Extension_Markdown());
 ```
 
 ## todo

--- a/README.mkd
+++ b/README.mkd
@@ -19,6 +19,7 @@ or
 ```php
 $app->register(~~twig~~);
 
+include '/path/to/markdown.php';
 include __DIR__.'/../vendor/twig-markdown/lib/Twig/Extensions/Core.php';
 $app['twig']->addExtension(new Twig_Markdown_Extension());
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "geta6/twig-markdown",
+    "authors": [
+        {
+            "name": "getakura",
+            "email": "getakura@gmail.com"
+        }
+    ],
+    "require": {
+        "twig/twig": "1.*"
+    },
+    "autoload": {
+        "psr-0" : {
+            "Twig_" : "lib/"
+        }
+    }
+}

--- a/lib/Twig/Extension/Markdown.php
+++ b/lib/Twig/Extension/Markdown.php
@@ -4,7 +4,7 @@ if (!defined('ENT_SUBSTITUTE')) {
     define('ENT_SUBSTITUTE', 8);
 }
 
-class Twig_Markdown_Extension extends Twig_Extension
+class Twig_Extension_Markdown extends Twig_Extension
 {
     public function getTokenParsers()
     {

--- a/lib/Twig/Extensions/Core.php
+++ b/lib/Twig/Extensions/Core.php
@@ -8,7 +8,6 @@ class Twig_Markdown_Extension extends Twig_Extension
 {
     public function getTokenParsers()
     {
-        include_once dirname(__FILE__).'/../TokenParser/Markdown.php';
         return array(
             new Twig_TokenParser_Markdown(),
         );
@@ -33,7 +32,6 @@ class Twig_Markdown_Extension extends Twig_Extension
 
 function twig_markdown($data)
 {
-    include_once dirname(__FILE__).'/../Markdown/markdown.php';
     return Markdown($data);
 }
 

--- a/lib/Twig/Node/Markdown.php
+++ b/lib/Twig/Node/Markdown.php
@@ -13,7 +13,6 @@ class Twig_Node_Markdown extends Twig_Node
      */
     public function compile(Twig_Compiler $compiler)
     {
-        include_once dirname(__FILE__).'/../Markdown/markdown.php';
         $compiler
             ->addDebugInfo($this)
             ->write("ob_start();\n")

--- a/lib/Twig/TokenParser/Markdown.php
+++ b/lib/Twig/TokenParser/Markdown.php
@@ -1,7 +1,5 @@
 <?php
 
-include_once dirname(__FILE__).'/../Node/Markdown.php';
-
 class Twig_TokenParser_Markdown extends Twig_TokenParser
 {
     /**


### PR DESCRIPTION
I changed the way to include "markdown.php".
I strongly suggest to include "markdown.php" outside this extension library.
So I added a composer.json file to make this extension more extensible and easy to use.
